### PR TITLE
Render pages as images for conversion

### DIFF
--- a/src/main/java/com/aschwimm/pdfmono/PDFMono.java
+++ b/src/main/java/com/aschwimm/pdfmono/PDFMono.java
@@ -1,24 +1,95 @@
 package com.aschwimm.pdfmono;
 
 import com.aschwimm.pdfmono.service.PDFConversionService;
+import com.aschwimm.pdfmono.service.PDFPageToImageToGrayscale;
+import com.aschwimm.pdfmono.util.PDFDocumentIO;
 import com.aschwimm.pdfmono.util.PDFInspector;
 
+import java.io.IOException;
+import java.nio.file.InvalidPathException;
+import java.nio.file.Paths;
+
+import static java.lang.Float.parseFloat;
+
 public class PDFMono {
+
+    // Set default DPI if arg isn't provided
+    private static final float DEFAULT_DPI = 150.0f;
+
+    // Standard usage reminder message
+    private static final String USAGE =
+            "Usage: java -jar PDFMono.jar <input-pdf-path> <output-pdf-path> [--dpi <value>]";
+
     public static void main(String[] args) {
-        if (args.length != 2) {
-            System.out.println("Usage: java -jar pdfmono.jar <input.pdf> <output.pdf>");
-            return;
+        String inputPath = null;
+        String outputPath = null;
+        float dpi = DEFAULT_DPI;
+
+        // Parse cmd line arguments
+        if (args.length < 2) {
+            System.err.println("Error: Missing input and/or output file paths.");
+            System.out.println(USAGE);
+            System.exit(1);
         }
-        String inputPath = args[0];
-        String outputPath = args[1];
-        PDFConversionService conversionService = new PDFConversionService();
-        boolean success = conversionService.convertToBlackAndWhite(inputPath, outputPath);
-        if(success) {
-            System.out.println("PDF converted successfully");
-        } else {
-            System.out.println("PDF conversion failed");
+        inputPath = args[0];
+        outputPath = args[1];
+        // Process optional arguments from the third argument onwards
+        for (int i = 2; i < args.length; i++) {
+            String arg = args[i];
+
+            if (arg.equals("--dpi")) {
+                if (i + 1 < args.length) {
+                    try {
+                        dpi = Float.parseFloat(args[++i]); // Increment i to consume the value
+                        if (dpi <= 0) {
+                            System.err.println("Error: DPI value must be a positive number.");
+                            System.out.println(USAGE);
+                            System.exit(1);
+                        }
+                    } catch (NumberFormatException e) {
+                        System.err.println("Error: Invalid DPI value. Please provide an integer or float.");
+                        System.out.println(USAGE);
+                        System.exit(1);
+                    }
+                } else {
+                    System.err.println("Error: --dpi option requires a value.");
+                    System.out.println(USAGE);
+                    System.exit(1);
+                }
+            }  else {
+                System.err.println("Error: Unknown option '" + arg + "'");
+                System.out.println(USAGE);
+                System.exit(1);
+            }
         }
-//        PDFInspector inspector = new PDFInspector();
-//        inspector.inspect(inputPath, outputPath);
+        try {
+            Paths.get(inputPath);
+            Paths.get(outputPath);
+        } catch (InvalidPathException e) {
+            System.err.println("Error: Invalid file path provided. " + e.getMessage());
+            System.out.println(USAGE);
+            System.exit(1);
+        }
+
+        PDFDocumentIO pdfDocumentIO = new PDFDocumentIO();
+        PDFPageToImageToGrayscale converter = new PDFPageToImageToGrayscale(pdfDocumentIO);
+        System.out.println("Converting '" + inputPath + "' to grayscale with DPI " + dpi + "...");
+        try {
+            // Call the method without the gamma boolean
+            converter.convertToGrayscalePDF(inputPath, outputPath, dpi);
+            System.out.println("Conversion complete! Output saved to: " + outputPath);
+        } catch (IllegalArgumentException e) {
+            System.err.println("\nInput Error: " + e.getMessage());
+            System.out.println(USAGE);
+            System.exit(1);
+        } catch (IOException e) {
+            System.err.println("\nI/O Error during PDF conversion: " + e.getMessage());
+            e.printStackTrace();
+            System.exit(1);
+        } catch (Exception e) {
+            System.err.println("\nAn unexpected error occurred during PDF conversion: " + e.getMessage());
+            e.printStackTrace();
+            System.exit(1);
+        }
     }
 }

--- a/src/main/java/com/aschwimm/pdfmono/service/PDFConversionService.java
+++ b/src/main/java/com/aschwimm/pdfmono/service/PDFConversionService.java
@@ -1,6 +1,7 @@
 package com.aschwimm.pdfmono.service;
 
 import com.aschwimm.pdfmono.util.ColorConverter;
+import com.aschwimm.pdfmono.util.PDFDocumentIO;
 import org.apache.pdfbox.Loader;
 import org.apache.pdfbox.contentstream.operator.Operator;
 import org.apache.pdfbox.cos.*;
@@ -54,7 +55,7 @@ public class PDFConversionService {
             return false;
         }
 
-        try (PDDocument document = loadDocument(inputFile)) {
+        try (PDDocument document = PDFDocumentIO.loadDocument(inputFile)) {
             for(PDPage page : document.getPages()) {
                 convertPageToGrayscale(document, page);
                 convertEmbeddedImagesToGrayscale(document, page);

--- a/src/main/java/com/aschwimm/pdfmono/service/PDFConversionService.java
+++ b/src/main/java/com/aschwimm/pdfmono/service/PDFConversionService.java
@@ -40,7 +40,11 @@ public class PDFConversionService {
     private Stack<PDColorSpace> nonStrokingColorSpaceStack;
     private Stack<PDColorSpace> strokingColorSpaceStack;
     int csCount = 0;
+    private final PDFDocumentIO pdfDocumentIO;
 
+    public PDFConversionService(PDFDocumentIO pdfDocumentIO) {
+        this.pdfDocumentIO = pdfDocumentIO;
+    }
     public boolean convertToBlackAndWhite(String inputFile, String outputFile) {
         File input = new File(inputFile);
         File output = new File(outputFile);
@@ -55,7 +59,7 @@ public class PDFConversionService {
             return false;
         }
 
-        try (PDDocument document = PDFDocumentIO.loadDocument(inputFile)) {
+        try (PDDocument document = pdfDocumentIO.loadDocument(inputFile)) {
             for(PDPage page : document.getPages()) {
                 convertPageToGrayscale(document, page);
                 convertEmbeddedImagesToGrayscale(document, page);

--- a/src/main/java/com/aschwimm/pdfmono/service/PDFConversionService.java
+++ b/src/main/java/com/aschwimm/pdfmono/service/PDFConversionService.java
@@ -1,5 +1,6 @@
 package com.aschwimm.pdfmono.service;
 
+import com.aschwimm.pdfmono.util.ColorConverter;
 import org.apache.pdfbox.Loader;
 import org.apache.pdfbox.contentstream.operator.Operator;
 import org.apache.pdfbox.cos.*;
@@ -60,7 +61,7 @@ public class PDFConversionService {
                 convertSeparationColorSpaceToGray(document, page);
             }
 
-            saveDocument(document, outputFile);
+            document.save(outputFile);
             return true;
         } catch (IOException e) {
             System.err.println("Error during conversion: " + e.getMessage());
@@ -68,17 +69,7 @@ public class PDFConversionService {
         }
 
     }
-    // Update how PDF files are loaded in PDFBox 3.0.5
-    private PDDocument loadDocument(String inputFile) throws IOException {
 
-        try{
-            File file = new File(inputFile);
-            return Loader.loadPDF(new RandomAccessReadBufferedFile(file));
-        } catch(IOException e) {
-            System.err.println("Error loading PDF: " + e.getMessage());
-            throw e;
-        }
-    }
     // This will only convert vector-based content like text, not inline vector paths like vector images in the content stream
    private void convertPageToGrayscale(PDDocument document, PDPage page) throws IOException {
         PDFStreamParser parser = new PDFStreamParser(page);
@@ -185,16 +176,6 @@ public class PDFConversionService {
             }
         }
     }
-    private void saveDocument(PDDocument document, String outputPath) throws IOException {
-        try (document) {
-            document.save(outputPath);
-        }
-    }
-
-    // This method converts an RGB color while preserving luminance
-    private float rgbToGray(float R, float G, float B) {
-        return 0.299f * R + 0.587f * G + 0.114f * B;
-    }
     private List<Object> convertInlineColorsToGray(List<Object> tokens, PDPage page) throws IOException {
         List<Object> newTokens = new ArrayList<>();
         for (int i = 0; i < tokens.size(); i++) {
@@ -203,11 +184,11 @@ public class PDFConversionService {
                 String name = operator.getName();
 
                 if(name.equals("rg") || name.equals("RG")) {
-                    float r = ((COSNumber) newTokens.remove(newTokens.size() - 3)).floatValue();
-                    float g = ((COSNumber) newTokens.remove(newTokens.size() - 2)).floatValue();
-                    float b = ((COSNumber) newTokens.remove(newTokens.size() - 1)).floatValue();
+                    int r = ((COSNumber) newTokens.remove(newTokens.size() - 3)).intValue();
+                    int g = ((COSNumber) newTokens.remove(newTokens.size() - 2)).intValue();
+                    int b = ((COSNumber) newTokens.remove(newTokens.size() - 1)).intValue();
 
-                    float gray = rgbToGray(r,g,b);
+                    float gray = ColorConverter.rgbToGray(r,g,b);
 
                     newTokens.add(COSFloat.get(String.valueOf(gray)));
                     newTokens.add(Operator.getOperator(name.equals("rg") ? "g" : "G"));
@@ -238,7 +219,7 @@ public class PDFConversionService {
                         }
 
                         float[] rgb = PDDeviceCMYK.INSTANCE.toRGB(new float[] { cVal, mVal, yVal, kVal });
-                        float gray = rgbToGray(rgb[0], rgb[1], rgb[2]);
+                        float gray = ColorConverter.rgbToGray(rgb);
 
                         newTokens.add(COSFloat.get(String.valueOf(gray)));
                         newTokens.add(Operator.getOperator(name.equals("k") ? "g" : "G"));

--- a/src/main/java/com/aschwimm/pdfmono/service/PDFPageToImageToGrayscale.java
+++ b/src/main/java/com/aschwimm/pdfmono/service/PDFPageToImageToGrayscale.java
@@ -1,0 +1,317 @@
+package com.aschwimm.pdfmono.service;
+
+import org.apache.pdfbox.Loader;
+import org.apache.pdfbox.io.RandomAccessReadBufferedFile;
+import org.apache.pdfbox.pdmodel.PDDocument;
+import org.apache.pdfbox.pdmodel.PDPage;
+import org.apache.pdfbox.pdmodel.PDPageContentStream;
+import org.apache.pdfbox.pdmodel.common.PDRectangle;
+import org.apache.pdfbox.pdmodel.graphics.image.PDImageXObject;
+import org.apache.pdfbox.rendering.ImageType;
+import org.apache.pdfbox.rendering.PDFRenderer;
+
+import javax.imageio.ImageIO;
+import java.awt.*;
+import java.awt.color.ColorSpace;
+import java.awt.image.BufferedImage;
+import java.awt.image.ColorConvertOp;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.IOException;
+
+import static com.aschwimm.pdfmono.service.PDFConversionService.loadDocument;
+import static com.aschwimm.pdfmono.service.PDFConversionService.saveDocument;
+
+
+public class PDFPageToImageToGrayscale {
+
+    public static boolean convertToGrayscalePDF(String inputPdfPath, String outputPdfPath, float dpi) {
+        File input = new File(inputPdfPath);
+        File output = new File(outputPdfPath);
+        if (!input.exists() || !input.isFile()) {
+            System.err.println("Input file does not exist or is not a valid file.");
+            return false;
+        }
+
+        if (!output.getParentFile().exists()) {
+            System.err.println("Output directory does not exist.");
+            return false;
+        }
+
+        PDDocument outputDocument = null;
+        try (PDDocument document = loadDocument(inputPdfPath)) {
+            outputDocument = new PDDocument();
+            PDFRenderer renderer = new PDFRenderer(document);
+            int pageCount = document.getNumberOfPages();
+
+            System.out.println("Converting " + pageCount + " pages to grayscale at " + dpi + " DPI...");
+
+            for (int i = 0; i < pageCount; i++) {
+                try {
+                    // FIXED: Use renderImageWithDPI instead of renderImage
+                    BufferedImage image = renderer.renderImageWithDPI(i, dpi, ImageType.RGB);
+                    BufferedImage grayScaleImage = convertToGrayscaleWithGamma(image);
+
+                    PDPage originalPage = document.getPage(i);
+                    PDRectangle originalPageSize = originalPage.getMediaBox();
+
+                    PDPage newPage = new PDPage(originalPageSize);
+                    outputDocument.addPage(newPage);
+
+                    PDImageXObject pdImage = PDImageXObject.createFromByteArray(
+                            outputDocument,
+                            bufferedImageToByteArray(grayScaleImage, "PNG"),
+                            "grayscale_page_" + (i + 1)
+                    );
+
+                    // Add image to the page
+                    try (PDPageContentStream contentStream = new PDPageContentStream(outputDocument, newPage)) {
+                        // Scale image to fit the page exactly
+                        contentStream.drawImage(pdImage, 0, 0,
+                                originalPageSize.getWidth(),
+                                originalPageSize.getHeight());
+                    }
+
+                    // Clean up memory
+                    image.flush();
+                    grayScaleImage.flush();
+
+                    System.out.println("Processed page " + (i + 1) + " of " + pageCount);
+
+                } catch (Exception e) {
+                    System.err.println("Error processing page " + (i + 1) + ": " + e.getMessage());
+                }
+            }
+
+            // FIXED: Save outputDocument instead of input document
+            saveDocument(outputDocument, outputPdfPath);
+            return true;
+
+        } catch(IOException e) {
+            System.err.println("Error during conversion: " + e.getMessage());
+            return false;
+        } finally {
+            // Clean up output document
+            if (outputDocument != null) {
+                try {
+                    outputDocument.close();
+                } catch (IOException e) {
+                    System.err.println("Error closing output document: " + e.getMessage());
+                }
+            }
+        }
+    }
+
+    // Helper method to convert BufferedImage to byte array
+    private static byte[] bufferedImageToByteArray(BufferedImage image, String format) throws IOException {
+        try (java.io.ByteArrayOutputStream baos = new java.io.ByteArrayOutputStream()) {
+            javax.imageio.ImageIO.write(image, format, baos);
+            return baos.toByteArray();
+        }
+    }
+
+    private static BufferedImage convertToGrayscaleLuminance(BufferedImage originalImage) {
+        BufferedImage grayscaleImage = new BufferedImage(
+                originalImage.getWidth(),
+                originalImage.getHeight(),
+                BufferedImage.TYPE_BYTE_GRAY
+        );
+
+        // Brightness adjustment factor (1.0 = no change, >1.0 = brighter, <1.0 = darker)
+        float brightnessBoost = 1.2f;
+
+        for (int y = 0; y < originalImage.getHeight(); y++) {
+            for (int x = 0; x < originalImage.getWidth(); x++) {
+                int rgb = originalImage.getRGB(x, y);
+
+                // Extract RGB components
+                int red = (rgb >> 16) & 0xFF;
+                int green = (rgb >> 8) & 0xFF;
+                int blue = rgb & 0xFF;
+
+                // Calculate luminance using standard formula
+                float gray = (0.299f * red + 0.587f * green + 0.114f * blue);
+
+                // Apply brightness boost
+                gray *= brightnessBoost;
+
+                // Clamp to valid range
+                int grayValue = Math.min(255, Math.max(0, (int) gray));
+
+                // Create grayscale RGB value
+                int grayRGB = (grayValue << 16) | (grayValue << 8) | grayValue;
+                grayscaleImage.setRGB(x, y, grayRGB);
+            }
+        }
+
+        return grayscaleImage;
+    }
+
+    // Alternative grayscale conversion methods with brightness adjustments
+    private static BufferedImage convertToGrayscaleWithGamma(BufferedImage originalImage) {
+        BufferedImage grayscaleImage = new BufferedImage(
+                originalImage.getWidth(),
+                originalImage.getHeight(),
+                BufferedImage.TYPE_BYTE_GRAY
+        );
+
+        // Gamma value increases brightness > 1, decreases brightness < 1
+        double gamma = 1.0;
+        double invGamma = 1.0 / gamma;
+
+        for (int y = 0; y < originalImage.getHeight(); y++) {
+            for (int x = 0; x < originalImage.getWidth(); x++) {
+                int rgb = originalImage.getRGB(x, y);
+
+                // Extract RGB components
+                int red = (rgb >> 16) & 0xFF;
+                int green = (rgb >> 8) & 0xFF;
+                int blue = rgb & 0xFF;
+
+                // Calculate luminance
+                double gray = (0.299 * red + 0.587 * green + 0.114 * blue) / 255.0;
+
+                // Apply gamma correction
+                gray = Math.pow(gray, invGamma);
+
+                // Convert back to 0-255 range
+                int grayValue = (int) Math.min(255, Math.max(0, gray * 255));
+
+                // Create grayscale RGB value
+                int grayRGB = (grayValue << 16) | (grayValue << 8) | grayValue;
+                grayscaleImage.setRGB(x, y, grayRGB);
+            }
+        }
+
+        return grayscaleImage;
+    }
+
+    // Method 2: Contrast and brightness adjustment
+    private static BufferedImage convertToGrayscaleWithContrast(BufferedImage originalImage) {
+        BufferedImage grayscaleImage = new BufferedImage(
+                originalImage.getWidth(),
+                originalImage.getHeight(),
+                BufferedImage.TYPE_BYTE_GRAY
+        );
+
+        // Adjustment parameters
+        float brightness = 30f;  // Add this value to brightness (-100 to +100)
+        float contrast = 1.2f;   // Multiply contrast (0.5 = low contrast, 2.0 = high contrast)
+
+        for (int y = 0; y < originalImage.getHeight(); y++) {
+            for (int x = 0; x < originalImage.getWidth(); x++) {
+                int rgb = originalImage.getRGB(x, y);
+
+                // Extract RGB components
+                int red = (rgb >> 16) & 0xFF;
+                int green = (rgb >> 8) & 0xFF;
+                int blue = rgb & 0xFF;
+
+                // Calculate luminance
+                float gray = (0.299f * red + 0.587f * green + 0.114f * blue);
+
+                // Apply contrast (center around 128)
+                gray = ((gray - 128) * contrast) + 128;
+
+                // Apply brightness
+                gray += brightness;
+
+                // Clamp to valid range
+                int grayValue = Math.min(255, Math.max(0, (int) gray));
+
+                // Create grayscale RGB value
+                int grayRGB = (grayValue << 16) | (grayValue << 8) | grayValue;
+                grayscaleImage.setRGB(x, y, grayRGB);
+            }
+        }
+
+        return grayscaleImage;
+    }
+
+    // Method 3: Histogram equalization for better distribution
+    private static BufferedImage convertToGrayscaleWithHistogramEqualization(BufferedImage originalImage) {
+        BufferedImage grayscaleImage = new BufferedImage(
+                originalImage.getWidth(),
+                originalImage.getHeight(),
+                BufferedImage.TYPE_BYTE_GRAY
+        );
+
+        int width = originalImage.getWidth();
+        int height = originalImage.getHeight();
+        int totalPixels = width * height;
+
+        // First pass: convert to grayscale and build histogram
+        int[] histogram = new int[256];
+        int[][] grayValues = new int[height][width];
+
+        for (int y = 0; y < height; y++) {
+            for (int x = 0; x < width; x++) {
+                int rgb = originalImage.getRGB(x, y);
+
+                int red = (rgb >> 16) & 0xFF;
+                int green = (rgb >> 8) & 0xFF;
+                int blue = rgb & 0xFF;
+
+                int gray = (int) (0.299 * red + 0.587 * green + 0.114 * blue);
+                grayValues[y][x] = gray;
+                histogram[gray]++;
+            }
+        }
+
+        // Build cumulative distribution function
+        int[] cdf = new int[256];
+        cdf[0] = histogram[0];
+        for (int i = 1; i < 256; i++) {
+            cdf[i] = cdf[i - 1] + histogram[i];
+        }
+
+        // Second pass: apply histogram equalization
+        for (int y = 0; y < height; y++) {
+            for (int x = 0; x < width; x++) {
+                int originalGray = grayValues[y][x];
+                int equalizedGray = (int) ((cdf[originalGray] * 255.0) / totalPixels);
+
+                int grayRGB = (equalizedGray << 16) | (equalizedGray << 8) | equalizedGray;
+                grayscaleImage.setRGB(x, y, grayRGB);
+            }
+        }
+
+        return grayscaleImage;
+    }
+
+    // Method 4: Simple averaging with brightness boost
+    private static BufferedImage convertToGrayscaleAverage(BufferedImage originalImage) {
+        BufferedImage grayscaleImage = new BufferedImage(
+                originalImage.getWidth(),
+                originalImage.getHeight(),
+                BufferedImage.TYPE_BYTE_GRAY
+        );
+
+        float brightnessBoost = 1.3f; // Adjust this value
+
+        for (int y = 0; y < originalImage.getHeight(); y++) {
+            for (int x = 0; x < originalImage.getWidth(); x++) {
+                int rgb = originalImage.getRGB(x, y);
+
+                // Extract RGB components
+                int red = (rgb >> 16) & 0xFF;
+                int green = (rgb >> 8) & 0xFF;
+                int blue = rgb & 0xFF;
+
+                // Simple average instead of luminance formula
+                float gray = (red + green + blue) / 3.0f;
+
+                // Apply brightness boost
+                gray *= brightnessBoost;
+
+                // Clamp to valid range
+                int grayValue = Math.min(255, Math.max(0, (int) gray));
+
+                int grayRGB = (grayValue << 16) | (grayValue << 8) | grayValue;
+                grayscaleImage.setRGB(x, y, grayRGB);
+            }
+        }
+
+        return grayscaleImage;
+    }
+}

--- a/src/main/java/com/aschwimm/pdfmono/util/ColorConverter.java
+++ b/src/main/java/com/aschwimm/pdfmono/util/ColorConverter.java
@@ -1,0 +1,19 @@
+package com.aschwimm.pdfmono.util;
+/*
+This class includes methods for simple color conversion
+ */
+public class ColorConverter {
+
+    // Standard grayscale conversion formula to be used with RGB values
+    public static float rgbToGray(int R, int G, int B) {
+        return 0.299f * R + 0.587f * G + 0.114f * B;
+    }
+
+    // Apply standard conversion formula to float array returned by org.apache.pdfbox.pdmodel.graphics.color.PDDeviceCMYK
+    public static float rgbToGray(float[] rgb) {
+        if (rgb == null || rgb.length < 3) {
+            throw new IllegalArgumentException("RGB array must not be null and must contain at least 3 elements.");
+        }
+        return (float) (0.299 * rgb[0] + 0.587 * rgb[1] + 0.114 * rgb[2]);
+    }
+}

--- a/src/main/java/com/aschwimm/pdfmono/util/PDFDocumentIO.java
+++ b/src/main/java/com/aschwimm/pdfmono/util/PDFDocumentIO.java
@@ -1,0 +1,25 @@
+package com.aschwimm.pdfmono.util;
+
+import org.apache.pdfbox.Loader;
+import org.apache.pdfbox.io.RandomAccessReadBufferedFile;
+import org.apache.pdfbox.pdmodel.PDDocument;
+
+import java.io.File;
+import java.io.IOException;
+
+/*
+This class handles PDF file I/O
+ */
+public class PDFDocumentIO {
+
+    // Update how PDF files are loaded for PDFBox 3.0.5
+    public static PDDocument loadDocument(String inputFile) throws IOException {
+
+        try{
+            File file = new File(inputFile);
+            return Loader.loadPDF(new RandomAccessReadBufferedFile(file));
+        } catch(IOException e) {
+            System.err.println("Error loading PDF: " + e.getMessage());
+            throw e;
+        }
+    }}

--- a/src/main/java/com/aschwimm/pdfmono/util/PDFDocumentIO.java
+++ b/src/main/java/com/aschwimm/pdfmono/util/PDFDocumentIO.java
@@ -13,7 +13,7 @@ This class handles PDF file I/O
 public class PDFDocumentIO {
 
     // Update how PDF files are loaded for PDFBox 3.0.5
-    public static PDDocument loadDocument(String inputFile) throws IOException {
+    public  PDDocument loadDocument(String inputFile) throws IOException {
 
         try{
             File file = new File(inputFile);


### PR DESCRIPTION
# Temporary working solution to convert a PDF's pages to grayscale

## Created a new class to iterate through a PDF's pages and render them as images before applying grayscale conversion
- The grayscale conversion achieves the desired result but certain PDF document properties like screen reader accessibility and text search is lost because all pages are now replaced with iamges

## Created two utility classes 
- `ColorConvert` Has two methods that apply the standard grayscale conversion formula. 
- First method takes three integers  for RGB values and returns the correct grayscale float value. 
- Second method takes an array of floats and is meant to be used with `org.apache.pdfbox.pdmodel.graphics.color.PDDeviceCMYK` per the `toRGB` method's signature

## Update logic in main 
- Check for optional argument to set DPI of rendered images
- Add IO validation
