### PR TITLE
Add CLI Argument Support to Distinguish Between Grayscale Conversion and Report Creation

### DIFF
--- a/src/main/java/com/aschwimm/pdfmono/PDFMono.java
+++ b/src/main/java/com/aschwimm/pdfmono/PDFMono.java
@@ -16,9 +16,12 @@ public class PDFMono {
     // Set default DPI if arg isn't provided
     private static final float DEFAULT_DPI = 150.0f;
 
-    // Standard usage reminder message
-    private static final String USAGE =
-            "Usage: java -jar PDFMono.jar <input-pdf-path> <output-pdf-path> [--dpi <value>]";
+    // Conversion usage reminder message
+    private static final String CONVERSION_USAGE =
+            "Usage: java -jar PDFMono.jar <input-pdf-path> <output-pdf-path> --grayscale [--dpi <value>]";
+    // Inspection usage reminder message
+    private static final String INSPECTION_USAGE =
+            "Usage: java -jar PDFMono.jar <input-pdf-path> <output-Markdown-report-path>";
 
     public static void main(String[] args) {
         String inputPath = null;
@@ -28,7 +31,7 @@ public class PDFMono {
         // Parse cmd line arguments
         if (args.length < 2) {
             System.err.println("Error: Missing input and/or output file paths.");
-            System.out.println(USAGE);
+            System.out.println(CONVERSION_USAGE);
             System.exit(1);
         }
         inputPath = args[0];
@@ -36,60 +39,114 @@ public class PDFMono {
         // Process optional arguments from the third argument onwards
         for (int i = 2; i < args.length; i++) {
             String arg = args[i];
-
-            if (arg.equals("--dpi")) {
-                if (i + 1 < args.length) {
-                    try {
-                        dpi = Float.parseFloat(args[++i]); // Increment i to consume the value
-                        if (dpi <= 0) {
-                            System.err.println("Error: DPI value must be a positive number.");
-                            System.out.println(USAGE);
+            // Check for arg to convert to grayscale
+            if(arg.equals("--grayscale")) {
+                // Check for option --dpi arg
+                if(i+1 < args.length) {
+                    String dpiArg =  args[i+1];
+                    if(dpiArg.equals("--dpi")) {
+                        if (i + 2 < args.length) {
+                            try {
+                                // Increment i to consume the value
+                                ++i;
+                                dpi = Float.parseFloat(args[++i]);
+                                if (dpi <= 0) {
+                                    System.err.println("Error: DPI value must be a positive number.");
+                                    System.out.println(CONVERSION_USAGE);
+                                    System.exit(1);
+                                }
+                            } catch (NumberFormatException e) {
+                                System.err.println("Error: Invalid DPI value. Please provide an integer or float.");
+                                System.out.println(CONVERSION_USAGE);
+                                System.exit(1);
+                            }
+                        } else {
+                            System.err.println("Error: --dpi option requires a value.");
+                            System.out.println(CONVERSION_USAGE);
                             System.exit(1);
                         }
-                    } catch (NumberFormatException e) {
-                        System.err.println("Error: Invalid DPI value. Please provide an integer or float.");
-                        System.out.println(USAGE);
-                        System.exit(1);
+                        try {
+                            Paths.get(inputPath);
+                            Paths.get(outputPath);
+                        } catch (InvalidPathException e) {
+                            System.err.println("Error: Invalid file path provided. " + e.getMessage());
+                            System.out.println(CONVERSION_USAGE);
+                            System.exit(1);
+                        }
+
+                        PDFDocumentIO pdfDocumentIO = new PDFDocumentIO();
+                        PDFPageToImageToGrayscale converter = new PDFPageToImageToGrayscale(pdfDocumentIO);
+                        System.out.println("Converting '" + inputPath + "' to grayscale with DPI " + dpi + "...");
+                        try {
+                            // Call the method without the gamma boolean
+                            converter.convertToGrayscalePDF(inputPath, outputPath, dpi);
+                        } catch (IllegalArgumentException e) {
+                            System.err.println("\nInput Error: " + e.getMessage());
+                            System.out.println(CONVERSION_USAGE);
+                            System.exit(1);
+                        } catch (IOException e) {
+                            System.err.println("\nI/O Error during PDF conversion: " + e.getMessage());
+                            e.printStackTrace();
+                            System.exit(1);
+                        } catch (Exception e) {
+                            System.err.println("\nAn unexpected error occurred during PDF conversion: " + e.getMessage());
+                            e.printStackTrace();
+                            System.exit(1);
+                        } finally {
+                            System.out.println("Conversion complete! Output saved to: " + outputPath);
+                            System.exit(0);
+                        }
                     }
-                } else {
-                    System.err.println("Error: --dpi option requires a value.");
-                    System.out.println(USAGE);
+                }
+                PDFDocumentIO pdfDocumentIO = new PDFDocumentIO();
+                PDFPageToImageToGrayscale converter = new PDFPageToImageToGrayscale(pdfDocumentIO);
+                System.out.println("Converting '" + inputPath + "' to grayscale with Default DPI: " + dpi + "...");
+                try {
+                    // Call the method without the gamma boolean
+                    converter.convertToGrayscalePDF(inputPath, outputPath, dpi);
+                    System.out.println("Conversion complete! Output saved to: " + outputPath);
+                } catch (IllegalArgumentException e) {
+                    System.err.println("\nInput Error: " + e.getMessage());
+                    System.out.println(CONVERSION_USAGE);
+                    System.exit(1);
+                } catch (IOException e) {
+                    System.err.println("\nI/O Error during PDF conversion: " + e.getMessage());
+                    e.printStackTrace();
+                    System.exit(1);
+                } catch (Exception e) {
+                    System.err.println("\nAn unexpected error occurred during PDF conversion: " + e.getMessage());
+                    e.printStackTrace();
                     System.exit(1);
                 }
-            }  else {
+            }
+
+            else if (arg.equals("--inspect")) {
+                // Temporary solution: concat .md file extension for outputPath arg until PDFInspector class is updated
+                // TODO: PDFInspector should handle file extensions not main
+                PDFDocumentIO pdfDocumentIO = new PDFDocumentIO();
+                PDFInspector inspector = new PDFInspector(pdfDocumentIO);
+                outputPath += ".md";
+                System.out.println("Inspecting " + inputPath + "...");
+                try {
+                    inspector.inspect(inputPath, outputPath);
+                    System.out.println("Inspection complete! Report saved to: " + outputPath);
+                } catch (IllegalArgumentException e) {
+                    System.err.println("\nInput Error: " + e.getMessage());
+                    System.out.println(CONVERSION_USAGE);
+                    System.exit(1);
+                } catch (Exception e) {
+                    System.err.println("\nAn unexpected error occurred during PDF inspection: " + e.getMessage());
+                    e.printStackTrace();
+                    System.exit(1);
+                }
+            }
+            else {
                 System.err.println("Error: Unknown option '" + arg + "'");
-                System.out.println(USAGE);
+                System.out.println(CONVERSION_USAGE);
                 System.exit(1);
             }
         }
-        try {
-            Paths.get(inputPath);
-            Paths.get(outputPath);
-        } catch (InvalidPathException e) {
-            System.err.println("Error: Invalid file path provided. " + e.getMessage());
-            System.out.println(USAGE);
-            System.exit(1);
-        }
 
-        PDFDocumentIO pdfDocumentIO = new PDFDocumentIO();
-        PDFPageToImageToGrayscale converter = new PDFPageToImageToGrayscale(pdfDocumentIO);
-        System.out.println("Converting '" + inputPath + "' to grayscale with DPI " + dpi + "...");
-        try {
-            // Call the method without the gamma boolean
-            converter.convertToGrayscalePDF(inputPath, outputPath, dpi);
-            System.out.println("Conversion complete! Output saved to: " + outputPath);
-        } catch (IllegalArgumentException e) {
-            System.err.println("\nInput Error: " + e.getMessage());
-            System.out.println(USAGE);
-            System.exit(1);
-        } catch (IOException e) {
-            System.err.println("\nI/O Error during PDF conversion: " + e.getMessage());
-            e.printStackTrace();
-            System.exit(1);
-        } catch (Exception e) {
-            System.err.println("\nAn unexpected error occurred during PDF conversion: " + e.getMessage());
-            e.printStackTrace();
-            System.exit(1);
-        }
+
     }
 }

--- a/src/main/java/com/aschwimm/pdfmono/service/PDFConversionService.java
+++ b/src/main/java/com/aschwimm/pdfmono/service/PDFConversionService.java
@@ -2,39 +2,27 @@ package com.aschwimm.pdfmono.service;
 
 import com.aschwimm.pdfmono.util.ColorConverter;
 import com.aschwimm.pdfmono.util.PDFDocumentIO;
-import org.apache.pdfbox.Loader;
 import org.apache.pdfbox.contentstream.operator.Operator;
 import org.apache.pdfbox.cos.*;
-import org.apache.pdfbox.io.RandomAccessReadBufferedFile;
 import org.apache.pdfbox.pdfparser.PDFStreamParser;
 import org.apache.pdfbox.pdfwriter.ContentStreamWriter;
 import org.apache.pdfbox.pdmodel.PDDocument;
 import org.apache.pdfbox.pdmodel.PDPage;
-import org.apache.pdfbox.pdmodel.PDPageContentStream;
 import org.apache.pdfbox.pdmodel.PDResources;
-import org.apache.pdfbox.pdmodel.common.COSDictionaryMap;
-import org.apache.pdfbox.pdmodel.common.PDRectangle;
 import org.apache.pdfbox.pdmodel.common.PDStream;
-import org.apache.pdfbox.pdmodel.common.function.PDFunction;
 import org.apache.pdfbox.pdmodel.common.function.PDFunctionType4;
 import org.apache.pdfbox.pdmodel.graphics.PDXObject;
 import org.apache.pdfbox.pdmodel.graphics.color.*;
 import org.apache.pdfbox.pdmodel.graphics.form.PDFormXObject;
 import org.apache.pdfbox.pdmodel.graphics.image.LosslessFactory;
 import org.apache.pdfbox.pdmodel.graphics.image.PDImageXObject;
-import org.apache.pdfbox.rendering.ImageType;
-import org.apache.pdfbox.rendering.PDFRenderer;
 
-import java.awt.color.ColorSpace;
-import java.awt.color.ICC_Profile;
-import java.awt.image.ColorConvertOp;
 import java.io.*;
 import java.nio.charset.StandardCharsets;
 import java.util.*;
 import java.awt.*;
 import java.awt.image.BufferedImage;
 import java.util.List;
-import java.util.stream.IntStream;
 
 public class PDFConversionService {
     private Stack<PDColorSpace> nonStrokingColorSpaceStack;


### PR DESCRIPTION
# PDFInspector Integration and Update to CLI Argument Handling

## PDFInspector 
- Feature was already built and ready to be integrated into main entry point
- Add handling for CLI arguments to generate an Markdown inspection report of PDF internals
- This is done with the `--inspect` flag after providing I/O arguments

## Update CLI Argument Handling
- Add handling of `--grayscale` flag instead of grayscale conversion being the program's default behavior
- Add handling for option argument to set DPI with `--dpi` flag